### PR TITLE
Improve artist/song matching

### DIFF
--- a/youtube.py
+++ b/youtube.py
@@ -40,7 +40,7 @@ class Youtube:
 
     def __fetch_songs(self, youtube, playlist_id, page_token=None):
         result = youtube.playlistItems().list(
-            part="snippet",
+            part="snippet, contentDetails",
             playlistId=playlist_id,
             maxResults="300",
             pageToken=page_token

--- a/youtube.py
+++ b/youtube.py
@@ -48,11 +48,21 @@ class Youtube:
 
         for item in result['items']:
             song = item['snippet']['title']
-            try:
-                artist, title = get_artist_title(song)
-                self.songs.append(clean_song_info(Song(artist, title)))
-            except:
-                print(f'Error parsing {song}')
+            videoId = item['contentDetails']['videoId']
+            response = youtube.videos().list(
+                part="snippet",
+                id=videoId
+            ).execute()
+            for video_item in response['items']:
+                separator = '-'
+                channelTitle = video_item['snippet']['channelTitle']
+                artist = channelTitle.split(separator, 1)[0]
+                songTitle = video_item['snippet']['localized']['title']
+                try:
+                    artist, title = get_artist_title(artist + " - " + songTitle)
+                    self.songs.append(clean_song_info(Song(artist, title)))
+                except:
+                    print(f'Error parsing {song}')
 
         return result
 


### PR DESCRIPTION
Migrating from youtube music playlist to Spotify, I have encountered too much Error and song not found during the process.
By leveraging on the unique video Id to find the original channel (artist name) this improved significantly the matching.